### PR TITLE
change loss.numpy()[0] to float(loss) to adapt 0D

### DIFF
--- a/ppdet/modeling/tests/test_yolov3_loss.py
+++ b/ppdet/modeling/tests/test_yolov3_loss.py
@@ -356,8 +356,8 @@ class TestYolov3LossOp(unittest.TestCase):
             x, t, gtbox, anchor, self.downsample_ratio, self.scale_x_y)
         for k in yolo_loss2:
             self.assertAlmostEqual(
-                yolo_loss1[k].numpy()[0],
-                yolo_loss2[k].numpy()[0],
+                float(yolo_loss1[k]),
+                float(yolo_loss2[k]),
                 delta=1e-2,
                 msg=k)
 


### PR DESCRIPTION
loss正确的语义为0D Tensor，其shape为[]，当前使用了shape为[1]替代，也就是向量Tensor：

在进行升级为0D后，loss.numpy()[0] 的写法不再使用，将其改变为 float(loss) 的写法，在升级前(shape为[1])、升级后(shape为[])下都同样适用，兼容改法。