### PR TITLE
add extra all_reduce for xpu

### DIFF
--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -422,6 +422,12 @@ class Trainer(object):
                     # model forward
                     outputs = model(data)
                     loss = outputs['loss']
+
+                    # avoid some all_reduce timeout due to computation progress differs between xpu cards
+                    if self._nranks > 1 and self.cfg.use_xpu:
+                        tensor_for_all_reduce = paddle.to_tensor(1.0)
+                        paddle.distributed.all_reduce(tensor_for_all_reduce)
+
                     # model backward
                     loss.backward()
                     self.optimizer.step()


### PR DESCRIPTION
XPU多卡训练过程中，某些卡计算完成后调用all reduce 等待其他卡的时间超过默认阈值。
这里在前向和后向之间，添加一个额外的all_reduce 操作，以减少all reduce 超时的出现。