### PR TITLE
use resnet_unit/yolo_unit fusion in yolov5 for xpu

### DIFF
--- a/configs/yolov5/_base_/yolov5_reader.yml
+++ b/configs/yolov5/_base_/yolov5_reader.yml
@@ -12,14 +12,16 @@ TrainReader:
     - RandomFlip: {}
     - BboxXYXY2XYWH: {}
     - NormalizeBox: {}
+  batch_transforms:
     - NormalizeImage: {mean: [0., 0., 0.], std: [1., 1., 1.], norm_type: none}
     - RGBReverse: {} # bgr->rgb
     - Permute: {}
+    - PadGT: {}
   batch_size: 8
   shuffle: True
   drop_last: False
-  use_shared_memory: False
-  collate_batch: False
+  use_shared_memory: True
+  collate_batch: True
   mosaic_epoch: *mosaic_epoch
 
 

--- a/configs/yolov5/_base_/yolov5_reader_high_aug.yml
+++ b/configs/yolov5/_base_/yolov5_reader_high_aug.yml
@@ -12,14 +12,16 @@ TrainReader:
     - RandomFlip: {}
     - BboxXYXY2XYWH: {}
     - NormalizeBox: {}
+  batch_transforms:
     - NormalizeImage: {mean: [0., 0., 0.], std: [1., 1., 1.], norm_type: none}
     - RGBReverse: {} # bgr->rgb
     - Permute: {}
+    - PadGT: {}
   batch_size: 8
   shuffle: True
   drop_last: False
-  use_shared_memory: False
-  collate_batch: False
+  use_shared_memory: True
+  collate_batch: True
   mosaic_epoch: *mosaic_epoch
 
 

--- a/ppdet/modeling/losses/yolov5_loss.py
+++ b/ppdet/modeling/losses/yolov5_loss.py
@@ -76,7 +76,7 @@ class YOLOv5Loss(nn.Layer):
         self.to_static = False
 
     def build_targets(self, outputs, targets, anchors):
-        if 0:
+        if 1:
             # collate_batch True
             # targets['gt_class'] [bs, max_gt_nums, 1]
             # targets['gt_bbox'] [bs, max_gt_nums, 4]


### PR DESCRIPTION
[Do Not Merge]
1、对csp_darknet backbone中的BaseConv进行fusion，通过YOLOv5_Fusion_ResnetUnit和YOLOv5_Fusion_YoloUnit环境变量进行控制，各自控制使用的fusion大算子，不开启则走默认的实现。
2、对yolov5_reader.yml文件中的use_shared_memory进行更改，该配置对模型训练性能会有很大影响。
3、AMP模式新增XPU后端支持。