### PR TITLE
add max_memory_reserved for benchmark

### DIFF
--- a/ppdet/engine/callbacks.py
+++ b/ppdet/engine/callbacks.py
@@ -1,15 +1,15 @@
-# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved. 
-#   
-# Licensed under the Apache License, Version 2.0 (the "License");   
-# you may not use this file except in compliance with the License.  
-# You may obtain a copy of the License at   
-#   
-#     http://www.apache.org/licenses/LICENSE-2.0    
-#   
-# Unless required by applicable law or agreed to in writing, software   
-# distributed under the License is distributed on an "AS IS" BASIS, 
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  
-# See the License for the specific language governing permissions and   
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 from __future__ import absolute_import
@@ -120,6 +120,8 @@ class LogPrinter(Callback):
                     eta_sec = eta_steps * batch_time.global_avg
                     eta_str = str(datetime.timedelta(seconds=int(eta_sec)))
                     ips = float(batch_size) / batch_time.avg
+                    max_mem_reserved = paddle.device.cuda.max_memory_reserved()
+                    max_mem_allocated = paddle.device.cuda.max_memory_allocated()
                     fmt = ' '.join([
                         'Epoch: [{}]',
                         '[{' + space_fmt + '}/{}]',
@@ -129,6 +131,8 @@ class LogPrinter(Callback):
                         'batch_cost: {btime}',
                         'data_cost: {dtime}',
                         'ips: {ips:.4f} images/s',
+                        'max_mem_reserved: {max_mem_reserved}',
+                        'max_mem_allocated: {max_mem_allocated}'
                     ])
                     fmt = fmt.format(
                         epoch_id,
@@ -139,7 +143,9 @@ class LogPrinter(Callback):
                         meters=logs,
                         btime=str(batch_time),
                         dtime=str(data_time),
-                        ips=ips)
+                        ips=ips,
+                        max_mem_reserved=max_mem_reserved,
+                        max_mem_allocated=max_mem_allocated)
                     logger.info(fmt)
             if mode == 'eval':
                 step_id = status['step_id']


### PR DESCRIPTION
训练benchmark 使用 API paddle.device.cuda.max_memory_reserved() 收集模型训练时的显存占用，因此本PR 修改 benchmark 打印日志部分，新增 max_mem_reserved max_mem_allocated 指标打印；如下：
[11/21 15:37:17] ppdet.engine INFO: Epoch: [0] [ 110/3125] eta: 0:24:11 lr: 0.000000 loss_box: 0.256545 loss_cls: 0.059035 loss_obj: 0.247987 loss: 0.563567 batch_cost: 0.4402 data_cost: 0.0004 ips: 18.1718 images/s max_mem_reserved: 11613581568 max_mem_allocated: 10151881472 