### PR TITLE
speed up yolo5

### DIFF
--- a/configs/yolov5/_base_/yolov5_reader_high_aug.yml
+++ b/configs/yolov5/_base_/yolov5_reader_high_aug.yml
@@ -18,7 +18,7 @@ TrainReader:
   batch_size: 8
   shuffle: True
   drop_last: False
-  use_shared_memory: False
+  use_shared_memory: True
   collate_batch: False
   mosaic_epoch: *mosaic_epoch
 

--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -369,6 +369,8 @@ class Trainer(object):
             model.train()
             iter_tic = time.time()
             for step_id, data in enumerate(self.loader):
+                if self.cfg.architecture =='YOLOv5':
+                    data["image"] = data["image"].cuda(blocking=False)
                 if self.cfg.architecture in [
                         'YOLOv5', 'YOLOv6', 'YOLOv7', 'YOLOv8'
                 ]:

--- a/ppdet/modeling/losses/yolov5_loss.py
+++ b/ppdet/modeling/losses/yolov5_loss.py
@@ -119,8 +119,8 @@ class YOLOv5Loss(nn.Layer):
                 gt_num = gt_nums[idx]
                 if gt_num == 0:
                     continue
-                gt_bbox = targets['gt_bbox'][idx][:gt_num]
-                gt_class = targets['gt_class'][idx][:gt_num] * 1.0
+                gt_bbox = targets['gt_bbox'][idx][:gt_num].numpy()
+                gt_class = targets['gt_class'][idx][:gt_num].numpy() * 1.0
                 img_idx = np.repeat(np.array([[idx]]), gt_num, axis=0)
                 gt_labels.append(
                     np.concatenate((img_idx, gt_class, gt_bbox), -1))


### PR DESCRIPTION
1. Dataloader产生的Tensor都是pinned的，在训练过程中会出现多出同步H2D拷贝，造成打断。
  a. 这个模型的修复，只需将data["image"]转为gpu，别的可以先不用转
2. 前向随机位置出现gap，被Dataloader线程抢占GIL锁，导致主线程阻塞，无法加载Kernel 
  a. 原因是将use_shared_memory设为了false
3. ema运算不需要构建反向图，构建反向图是耗时的。可以加with no_grad
4. 有一段loss的运算在CPU上就可以，放到GPU上反而更慢
5. 本地实验，以上改动可以将IPS从60提升到100