### PR TITLE
Replaced the deprecated textsize method in ImageDraw

### DIFF
--- a/ppdet/utils/visualizer.py
+++ b/ppdet/utils/visualizer.py
@@ -125,7 +125,8 @@ def draw_bbox(image, im_id, catid2name, bboxes, threshold):
 
         # draw label
         text = "{} {:.2f}".format(catid2name[catid], score)
-        tw, th = draw.textsize(text)
+        l, t, r, b = draw.textbbox((0, 0), text)
+        tw, th = r - l, b - t
         draw.rectangle(
             [(xmin + 1, ymin - th), (xmin + tw + 1, ymin)], fill=color)
         draw.text((xmin + 1, ymin - th), text, fill=(255, 255, 255))


### PR DESCRIPTION
ImageDraw 的 textsize 在 Pillow 9.5 被弃用且已经在 Pillow 10 (2023-07-01) 被移除。在 PaddleYOLO/ppdet/utils/visualizer.py(128) 使用了 textsize 方法，这将导致使用版本大于10的 Pillow 时报错。如：
![image](https://github.com/PaddlePaddle/PaddleYOLO/assets/93063038/3bd22a60-09d0-4183-9590-10e7238f9905)
