### PR TITLE
speed up yolo5

### DIFF
--- a/configs/yolov5/_base_/yolov5_reader_high_aug.yml
+++ b/configs/yolov5/_base_/yolov5_reader_high_aug.yml
@@ -3,7 +3,7 @@ input_width: &input_width 640
 input_size: &input_size [*input_height, *input_width]
 mosaic_epoch: &mosaic_epoch 290 # last 10 epochs close mosaic, totally 300 epochs as default
 
-worker_num: 4
+worker_num: 8
 TrainReader:
   sample_transforms:
     - DecodeNormResize: {target_size: *input_size, mosaic: True}


### PR DESCRIPTION
https://github.com/PaddlePaddle/PaddleYOLO/pull/222 优化性能后，Dataloader加载速度跟不上训练速度。调整num_worker后性能可以提升到116