### PR TITLE
Fix misalignment between SOT and dynamic mode

### DIFF
--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -510,6 +510,7 @@ class Trainer(object):
 
                 self.status['data_time'].update(time.time() - iter_tic)
                 self.status['step_id'] = step_id
+                profiler.add_profiler_step(profiler_options)
                 self._compose_callback.on_step_begin(self.status)
                 data['epoch_id'] = epoch_id
                 data['num_gpus'] = self._nranks

--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -510,7 +510,6 @@ class Trainer(object):
 
                 self.status['data_time'].update(time.time() - iter_tic)
                 self.status['step_id'] = step_id
-                profiler.add_profiler_step(profiler_options)
                 self._compose_callback.on_step_begin(self.status)
                 data['epoch_id'] = epoch_id
                 data['num_gpus'] = self._nranks

--- a/ppdet/modeling/losses/yolov5_loss.py
+++ b/ppdet/modeling/losses/yolov5_loss.py
@@ -213,15 +213,12 @@ class YOLOv5Loss(nn.Layer):
                 # loss_cls = self.BCEcls(ps[:, 5:], t)
 
                 t = paddle.full_like(ps[:, 5:], self.cls_neg_label)
-                if not self.to_static:
-                    t = paddle.put_along_axis(
-                        t,
-                        t_cls.unsqueeze(-1),
-                        values=self.cls_pos_label,
-                        axis=1)
-                else:
-                    for i in range(n):
-                        t[i, t_cls[i]] = self.cls_pos_label
+
+                t = paddle.put_along_axis(
+                    t,
+                    t_cls.unsqueeze(-1),
+                    values=self.cls_pos_label,
+                    axis=1)
 
                 loss_cls = self.BCEcls(ps[:, 5:], t)
 


### PR DESCRIPTION
`yolov5_loss`函数中SOT和动态图的行为没有对齐，导致SOT性能大幅度落后于动态图模式。

在`forward`函数中，还存在一处不对齐行为：
```python
if not self.to_static:
            tcls, tbox, indices, anch = self.build_targets(inputs, targets,
                                                           anchors)
else:
    tcls, tbox, indices, anch = self.build_targets_paddle(
        inputs, targets, anchors)
```
但是此处对执行性能无明显影响，暂不做出修改。

SOT模式下开启`use_shared_memory`执行会出错，暂未修复，详见`修复记录`.

目前开启`use_shared_memory`的情况下，动转静会报错，暂未修复。