### PR TITLE
Remove config update logic in benchmark script for dy2st mode

### DIFF
--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -173,6 +173,13 @@ else
     device_num_list=($device_num)
 fi
 
+if [[ ${model_name} =~ "yolov5" ]];then 
+   echo "${model_name} run unset MosaicPerspective and RandomHSV"
+   eval "sed -i '10c 10c    - MosaicPerspective: {mosaic_prob: 0.0, target_size: *input_size, scale: 0.9, mixup_prob: 0.1, copy_paste_prob: 0.1}' configs/yolov5/_base_/yolov5_reader_high_aug.yml"
+   eval "sed -i 's/10c//' configs/yolov5/_base_/yolov5_reader_high_aug.yml"
+   eval "sed -i 's/^    - RandomHSV: /#&/' configs/yolov5/_base_/yolov5_reader_high_aug.yml"
+fi
+
 # for log name
 to_static=""
 # parse "to_static" options and modify trainer into "to_static_trainer"

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -179,9 +179,6 @@ to_static=""
 if [[ ${model_type} = "dynamicTostatic" ]];then
     to_static="d2sT_"
     sed -i 's/trainer:norm_train/trainer:to_static_train/g' $FILENAME
-    #yolov7 static need MosaicPerspective
-    eval "sed -i '10c 10c    - MosaicPerspective: {mosaic_prob: 1.0, target_size: *input_size, scale: 0.9, mixup_prob: 0.1, copy_paste_prob: 0.1}' configs/yolov7/_base_/yolov7_reader.yml"
-    eval "sed -i 's/10c//' configs/yolov7/_base_/yolov7_reader.yml"
 fi
 
 

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -173,22 +173,13 @@ else
     device_num_list=($device_num)
 fi
 
-if [[ ${model_name} =~ "yolov5" ]];then 
-   echo "${model_name} run unset MosaicPerspective and RandomHSV"
-   eval "sed -i '10c 10c    - MosaicPerspective: {mosaic_prob: 0.0, target_size: *input_size, scale: 0.9, mixup_prob: 0.1, copy_paste_prob: 0.1}' configs/yolov5/_base_/yolov5_reader_high_aug.yml"
-   eval "sed -i 's/10c//' configs/yolov5/_base_/yolov5_reader_high_aug.yml"
-   eval "sed -i 's/^    - RandomHSV: /#&/' configs/yolov5/_base_/yolov5_reader_high_aug.yml"
-fi
-
 # for log name
 to_static=""
 # parse "to_static" options and modify trainer into "to_static_trainer"
 if [[ ${model_type} = "dynamicTostatic" ]];then
     to_static="d2sT_"
     sed -i 's/trainer:norm_train/trainer:to_static_train/g' $FILENAME
-    #yolov5 and yolov7 static need MosaicPerspective
-    eval "sed -i '10c 10c    - MosaicPerspective: {mosaic_prob: 1.0, target_size: *input_size, scale: 0.9, mixup_prob: 0.1, copy_paste_prob: 0.1}' configs/yolov5/_base_/yolov5_reader_high_aug.yml"
-    eval "sed -i 's/10c//' configs/yolov5/_base_/yolov5_reader_high_aug.yml"
+    #yolov7 static need MosaicPerspective
     eval "sed -i '10c 10c    - MosaicPerspective: {mosaic_prob: 1.0, target_size: *input_size, scale: 0.9, mixup_prob: 0.1, copy_paste_prob: 0.1}' configs/yolov7/_base_/yolov7_reader.yml"
     eval "sed -i 's/10c//' configs/yolov7/_base_/yolov7_reader.yml"
 fi


### PR DESCRIPTION
#108 在动转静下将 yaml 配置里的 `MosaicPerspective.mosaic_prob` 设置为了 `1.0`，而修改后动态图和动转静期是都是会挂在 dataloader 的，不修改的话动态图和动转静都不会挂，因此移除该修改，使动态图和动转静保持一致