### PR TITLE
update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,16 @@
--   repo: https://github.com/PaddlePaddle/mirrors-yapf.git
-    sha: 0d79c0c469bab64f7229c9aca2b1186ef47f0e37
+repos:
+-   repo: https://github.com/psf/black
+    rev: 25.1.0
     hooks:
-    -   id: yapf
+    -   id: black
         files: \.py$
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.9
+    hooks:
+    -   id: ruff
+        args: [--fix]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    sha: a11d9314b22d8f8c7556443875b731ef05965464
+    rev: v5.0.0
     hooks:
     -   id: check-merge-conflict
     -   id: check-symlinks
@@ -15,7 +21,7 @@
     -   id: trailing-whitespace
         files: \.(md|yml)$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    sha: v1.0.1
+    rev: v1.5.5
     hooks:
     -   id: forbid-crlf
         files: \.(md|yml)$


### PR DESCRIPTION
This pull request updates the `.pre-commit-config.yaml` file to replace and add pre-commit hooks, as well as update the versions of existing hooks. The most important changes include switching from `yapf` to `black` for Python formatting, adding the `ruff` hook, and updating the version of the `pre-commit-hooks` and `Lucas-C/pre-commit-hooks` repositories.

Updates to pre-commit hooks:

* Replaced the `yapf` hook with the `black` hook for Python formatting (`.pre-commit-config.yaml`).
* Added the `ruff` hook with the `--fix` argument (`.pre-commit-config.yaml`).

Version updates:

* Updated the `pre-commit-hooks` repository to version `v5.0.0` (`.pre-commit-config.yaml`).
* Updated the `Lucas-C/pre-commit-hooks` repository to version `v1.5.5` (`.pre-commit-config.yaml`).