### PR TITLE
Fix: Corrected interpolation parameter in LetterResize to resolve Ope…

### DIFF
--- a/ppdet/data/transform/operators.py
+++ b/ppdet/data/transform/operators.py
@@ -4761,7 +4761,7 @@ class LetterResize(BaseOperator):
             # compare with no resize and padding size
             image = cv2.resize(
                 image, (no_pad_shape[1], no_pad_shape[0]),
-                interpolation='bilinear')
+                interpolation=cv2.INTER_LINEAR)
 
         scale_factor = (no_pad_shape[1] / image_shape[1],
                         no_pad_shape[0] / image_shape[0])


### PR DESCRIPTION
…nCV error

我在使用 PaddleYOLO 的评估功能时，发现了 LetterResize 操作的一个问题。

问题现象 (The issue):

当 input_size 尺寸超过 640（例如 672, 768 等）时，yolov10模型在评估阶段会抛出以下错误：

OpenCV(4.5.5) :-1: error: (-5:Bad argument) in function 'resize' > Argument 'interpolation' is required to be an integer

经过代码排查，我定位到问题源于 ppdet/data/transform/operators.py 文件中的 LetterResize 类。

错误原因 (The cause):

在 _resize_img 方法内部，cv2.resize 函数的 interpolation 参数被硬编码为字符串 'bilinear'，而不是 Python 可以识别的常量 cv2.INTER_LINEAR。这导致了类型错误，使得程序无法正常执行。

解决方案 (The fix):

该问题无法通过修改配置文件来解决，需要直接修改源代码。我将 interpolation='bilinear' 这一行代码改成了 interpolation=cv2.INTER_LINEAR。这个改动确保了 cv2.resize 函数接收到正确的整数类型参数，从而解决了报错问题。